### PR TITLE
Advantech I2C watchdog (MSP430-based) timing fix

### DIFF
--- a/drivers/watchdog/watchdog_advantech.c
+++ b/drivers/watchdog/watchdog_advantech.c
@@ -322,7 +322,7 @@ static int adv_wdt_i2c_probe(struct i2c_client *client)
 	wdev->wdt_ping_status = gpiod_is_active_low(gpio_wdt_ping_desc);
 
 	gpio_direction_output(wdev->gpio_wdt_ping, !wdev->wdt_ping_status);
-	msleep(10);
+	msleep(50);
 	gpio_direction_output(wdev->gpio_wdt_ping, wdev->wdt_ping_status);
 
 	wdev->wdog.timeout = clamp_t(unsigned, timeout, 1, ADV_WDT_MAX_TIME);


### PR DESCRIPTION
Fixes a double reboot bug caused by the probe function not holding the 'ping' signal long enough. The duration is updated from 10ms to 50ms, aligning with the timing used in the adv_wdt_ping function.

Observations:

The fix could be applied to all the branches having similar or the same code:

adv_4.1.15_2.0.0_ga
adv_4.14.98_2.0.0_ga
adv_5.10.35_2.0.0
adv_5.10.72_2.2.0
adv_5.15.52_2.1.0
adv_5.15.52_2.1.0_next
adv_5.15.52_2.1.0_RS08
adv_5.15.52_2.1.0_RS12
adv_5.4.24_2.1.0
adv_5.4.70_2.3.0
adv_5.4.70_2.3.0_DTOS
adv_5.4.70_2.3.0_epcr5710
adv_5.4.70_2.3.0_rm02
adv_5.4.70_2.3.2
adv_6.1.1_1.0.0
adv_6.1.22_2.0.0
adv_6.1.36
adv_6.6.23_2.0.0 (same code as this branch)
adv_6.6.23_2.0.0_rs16
adv_6.6.3_1.0.0  (same code as this branch)
adv_6.6.36_2.1.0  (this branch)

